### PR TITLE
AddingPowerSupport_For_golang-github-retailnext-hllpp

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+arch:
+  - amd64
+  - ppc64le
 language: go
 
 go:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,9 @@ language: go
 go:
   - "1.4"
   - tip
+jobs:
+ exclude:
+  - go: "1.4"
+    arch: amd64
+  - go: "1.4"
+    arch: ppc64le


### PR DESCRIPTION
Adding power support ppc64le.

This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. For more info tag @gerrith3.

The build is successful on both arch: amd64/ppc64le, the go version 1.4 is excluded as the same is not supported on power & Intel.
please find the Travis Link below.
https://travis-ci.com/github/santosh653/hllpp

Please let me know if you need any further details or If I am missing any?

Thank You !!